### PR TITLE
fix: typo in dependencies in resteasyclient.java

### DIFF
--- a/examples/resteasyclient.java
+++ b/examples/resteasyclient.java
@@ -1,8 +1,8 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS com.fasterxml.jackson.core:jackson-databind:2.9.8
-//DEPS org.jboss.reasteasy:resteasy-client:4.5.2.Final
-//DEPS org.jboss.reasteasy:resteasy-jackson2-provider:4.5.2.Final
+//DEPS org.jboss.resteasy:resteasy-client:4.5.2.Final
+//DEPS org.jboss.resteasy:resteasy-jackson2-provider:4.5.2.Final
 //REPOS mavencentral, google, jcenter
 
 import picocli.CommandLine;


### PR DESCRIPTION
It's ` org.jboss.resteasy`, not ` org.jboss.reasteasy`.

Fixes compilation error:

```
❯ jbang resteasyclient.java
[jbang] Resolving dependencies...
[jbang] info.picocli:picocli:jar:4.5.0
         com.fasterxml.jackson.core:jackson-databind:jar:2.9.8
         org.jboss.reasteasy:resteasy-client:jar:4.5.2.Final
         org.jboss.reasteasy:resteasy-jackson2-provider:jar:4.5.2.Final
[jbang] [ERROR] Could not resolve dependencies from mavencentral=https://repo1.maven.org/maven2/, google=https://maven.google.com/
Unable to collect/resolve dependency tree for a resolution due to: The following artifacts could not be resolved: org.jboss.reasteasy:resteasy-client:jar:4.5.2.Final, org.jboss.reasteasy:resteasy-jackson2-provider:jar:4.5.2.Final: Could not find artifact org.jboss.reasteasy:resteasy-client:jar:4.5.2.Final in mavencentral (https://repo1.maven.org/maven2/), caused by: Could not find artifact org.jboss.reasteasy:resteasy-client:jar:4.5.2.Final in mavencentral (https://repo1.maven.org/maven2/)
  The following artifacts could not be resolved: org.jboss.reasteasy:resteasy-client:jar:4.5.2.Final, org.jboss.reasteasy:resteasy-jackson2-provider:jar:4.5.2.Final: Could not find artifact org.jboss.reasteasy:resteasy-client:jar:4.5.2.Final in mavencentral (https://repo1.maven.org/maven2/)
```